### PR TITLE
Add assert in Main class that jude cannot be null

### DIFF
--- a/src/main/java/jude/Main.java
+++ b/src/main/java/jude/Main.java
@@ -26,6 +26,10 @@ public class Main extends Application {
             stage.setScene(scene);
 
             MainWindow controller = fxmlLoader.getController();
+
+            // Assert jude should not be null
+            assert jude != null : "jude should not be null";
+
             controller.setJude(jude);
 
             controller.setStage(stage);

--- a/src/main/java/jude/Storage.java
+++ b/src/main/java/jude/Storage.java
@@ -84,7 +84,6 @@ public class Storage {
      * @throws JudeException if there was an error while creating a save file.
      */
     public void save(TaskList list) throws JudeException {
-        // Write to the save file
         try {
             writer = new FileWriter(filePath);
             writer.write(list.toFileFormat());


### PR DESCRIPTION
There is an assumption that the default file path is correct. In some cases where the parent directory is not present, the program will output IOException when loading the save file.

Asserting the path existence assures the correct code behaviour.

As a step towards such correction, let's assert the jude instance cannot be null.